### PR TITLE
docs: initial commit of README

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,36 @@
+# top-most EditorConfig file
+root = true
+
+# defaults
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 80
+indent_style = space
+indent_size = 2
+
+# TOML
+# https://github.com/toml-lang/toml/tree/master/examples
+[*.toml]
+indent_size = 2
+
+[package.json]
+indent_size = 2
+
+
+# https://google.github.io/styleguide/docguide/style.html
+[*.md]
+trim_trailing_whitespace = false
+indent_size = 4
+indent_style = space
+
+[*.yaml]
+indent_style = space
+indent_size = 2
+
+# https://google.github.io/styleguide/shellguide.html#formatting
+[*.sh]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+`tp` is a GitHub [CLI](https://github.com/cli/cli) extension to create GitHub pull requests with [GitHub Flavored Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/about-writing-and-formatting-on-github) containing the output from an [OpenTofu](https://opentofu.org/) or [Terraform](https://www.terraform.io/) plan's output [^1] [^2], wrapped around a [`<details></details>`](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections) block so the plan output can be collapsed for easier reading. The body of your pull request will look like this [example](./example/EXAMPLE-PR.md) in the example directory.
+
+> [!TIP]
+> View it in 'rich diff' mode to see the rendered view.
+
+## Getting Started | Installation
+
+```bash
+gh ext install esacteksab/gh-tp
+```
+
+### `.tp` config file
+
+I didn't want to make assumptions about your system, so `tp` does not define any default values today. `tp` uses a config file named `.tp`. This config file is written in [YAML](https://yaml.org/). The file today is rudimentary. It has 3 required parameters with one optional parameter. It can exist in your home directory or in the root of your project from where you will execute `gh tp` from. A annotated copy exists in the [example](./example) directory. **_The config file, the parameters and possibly the presence of default values is actively being worked on. This behavior may change in a future release._**
+
+| Parameter | Type   | Required | Description                                                                                                            |
+| --------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| binary    | string | Y        | The name of the binary that you use. (e.g. `tofu` or `terraform`). It is expected to be in your $PATH. _Default: `""`_ |
+| planfile  | string | Y        | The name of the plan output file. _Default: `""`_                                                                      |
+| mdfile    | string | Y        | The name of the markdown file. _Default: `""`_                                                                         |
+| no-color  | bool   | N        | If `true`, `tp` will emit no color on the terminal. _Default: `false`_                                                 |
+
+### Using `tp`
+
+To create a plan and the markdown from that plan, run
+
+```bash
+gh tp
+```
+
+Two files will be created, the first an output file named, what you defined for the value of `planfile` in `.tp` config and a Markdown file named what you defined for the value of the parameter `mdfile` in the `.tp` config file. While the end goal of this extension is to submit the pull request, that functionality doesn't exist on a public branch yet. **This feature exists in a prototype branch. It will be public _soon_!**
+
+If you're targeting a resource, you can still get markdown from that plan's output. `tp` reads from `stdin` like so:
+
+```bash
+terraform plan -out plan.out -no-color  | gh tp -
+```
+
+Like with `gh tp` two files will exist. The first being whatever you passed to `-out` for the file name in the above example (`plan.out` in the example above) and the Markdown file named whatever you defined as the value for the `mdfile` parameter in the `.tp` config file. `tp` does not create an additional plan having been passed the plan from `stdin`.
+
+<!--`tp` also supports command-line flags as well as source environment variables. More [below](#disclaimer)-->
+
+> [!WARNING]
+> **_Pre 1.0.0 Alert_**. This is a new extension and as a result, the API isn't set yet. There have been two prototypes so far. The experiences from both have shaped what exists today, but there is still quite a bit left to do. So as I continue down the path of figuring things out, things are almost certainly going to change. **_Expect_** breaking changes in the early releases. I will _strive_ not to publish broken builds and will lean into Semver to identify `alpha`, `beta` and pre-releases.
+
+## Motivation
+
+I write _a lot_ of Terraform daily and a part of that process includes submitting pull requests for review by peers prior to applying the plan and merging the pull request. It can be tedious, sometimes cumbersome to run a `terraform plan -out plan.out`, copy the output from the terminal, do Git "things", open a pull request, paste the contents of the plan's output into the body of the pull request, wrap it in a code block, then wrap _that_ in a `<details></details>` block because some Terraform output can be quite lengthy and in an effort to provide a better experience and quicker access to the pull request's comments, we use the `<details></details>` mechanism to collapse the plan's output. You can use [pull request Templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests) to short-circuit some of this workflow with the template already containing a pre-formatted code block wrapped in a `<details></details>` so all you have to do is paste your plan in the WYSIWYG editor and hit submit.
+
+~~But I'm _lazy_~~, I mean, I'm _intentional_ with the things that take my time and attention, so I dug into letting the robots do what they do best and `tp` was born! The first prototype of this was a shell script and some `sed` and `awk` leveraging existing functionality present in `gh`. I decided to continue to iterate and extend it further by writing this extension in Go.
+
+## What tp isn't
+
+I feel like I'm in this _weird_ space. I programmatically run a `terraform plan -out plan.out --no-color` but Terraform _already_ does that. And it's not my intent to create a wrapper around an existing tool, especially one like Terraform. I also programmatically do a `gh pr create -t $title -F file.md`, but `gh` _already_ does that. So while I find my fit in the space, I felt it was important to call out what I'm not going to do. Today, it's not uncommon for me to have to do a `-target` to plan/apply around something. `tp` doesn't natively support passing arguements to Terraform. And I don't think I want it to. So in the example of not being able to pass the `-target` argument, but still desiring to create the formatted Markdown and the subsequent pull request, `tp` can read from `stdin` so today you can run `terraform plan -target resource.name -out plan.out | gh tp -` and `tp` will create the Markdown with your plan's output.
+
+## Contribute
+
+### Local Development Setup
+
+#### Disclaimer
+
+> [!NOTE]
+> This is a personal project that was born out of need and want to automate the repetitive task out of my life. `tp` is in no way affiliated with or associated with Terraform, HashiCorp, OpenTofu or any entities official or unofficial. The views expressed here are my own and don't reflect any past, current or future employer.
+
+<!--I'm left feeling like "Create the targeted plan with Terraform and let `tp` do the rest! While doing early prototyping, leaning into HashiCorp's example of how to use the `terraform-exec` library, I had in a `tf.Init` and while iterating, I kept doing an init and it kept downloading providers. I'm pretty certain I got rate-limited by the registry. So do I allow a `-i --init` to be passed so folks can do it when they need to or do I jump back on the side of "Have Terraform do the init, come back to `tp` when you're ready!"?-->
+
+[^1]: https://opentofu.org/docs/cli/commands/plan/#other-options <!-- markdownlint-disable-line MD034 -->
+
+[^2]: https://developer.hashicorp.com/terraform/cli/commands/plan#out-filename <!-- markdownlint-disable-line MD034 -->

--- a/example/EXAMPL-tp.yml
+++ b/example/EXAMPL-tp.yml
@@ -1,0 +1,12 @@
+# Save this to your $HOME directory as `.tp`
+# Or save it to the repository's root directory as `.tp`
+# Currently no file extension
+# Currently expects YAML
+# Name of the binary (e.g terraform or tofu. Must exist in your $PATH)
+binary: terraform
+# Plan output file created with `gh tp`
+planfile: "plan.out"
+# Markdown file created with `gh tp``
+mdfile: "plan.md"
+# set to true to disable colors in the terminal
+no-color: false

--- a/example/EXAMPLE-PR.md
+++ b/example/EXAMPLE-PR.md
@@ -1,0 +1,74 @@
+<!-- markdownlint-disable MD033 -->
+
+<details><summary>Terraform Plan</summary>
+
+```terraform
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # archive_file.tf_pr will be created
+  + resource "archive_file" "tf_pr" {
+      + id                  = (known after apply)
+      + output_base64sha256 = (known after apply)
+      + output_base64sha512 = (known after apply)
+      + output_md5          = (known after apply)
+      + output_path         = "./tf-pr.tar.gz"
+      + output_sha          = (known after apply)
+      + output_sha256       = (known after apply)
+      + output_sha512       = (known after apply)
+      + output_size         = (known after apply)
+      + source_file         = "./.tf-pr"
+      + type                = "tar.gz"
+    }
+
+  # local_file.pet will be created
+  + resource "local_file" "pet" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "./pet.out"
+      + id                   = (known after apply)
+    }
+
+  # local_file.uuid will be created
+  + resource "local_file" "uuid" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "./uuid.out"
+      + id                   = (known after apply)
+    }
+
+  # random_pet.pet will be created
+  + resource "random_pet" "pet" {
+      + id        = (known after apply)
+      + length    = 2
+      + separator = "-"
+    }
+
+  # random_uuid.uuid will be created
+  + resource "random_uuid" "uuid" {
+      + id     = (known after apply)
+      + result = (known after apply)
+    }
+
+Plan: 5 to add, 0 to change, 0 to destroy.
+```
+
+</details>


### PR DESCRIPTION
In addition to `README.md` also an `.editorconfig` to appease Prettier and an example Markdown file produced by `gh tp` and an example config file to use as reference.