### PR TITLE
ci(dpeendabot): labels don't belong in schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,5 +13,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      Labels:
-        - "type: ci/cd"
+    labels:
+      - "type: ci/cd"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
     rev: 0.31.2
     hooks:
       - id: check-github-workflows
+      - id: check-dependabot
       - id: check-jsonschema
         name: "Validate Pre-Commit"
         files: ^\.pre-commit-config.yaml+$


### PR DESCRIPTION
- An attempt to fix [this](https://github.com/esacteksab/gh-tp/pull/41/checks?check_run_id=38133304673)
