### PR TITLE
style: This corrects the ordreing of the output in the terminal

### DIFF
--- a/cmd/markdown.go
+++ b/cmd/markdown.go
@@ -3,13 +3,11 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/charmbracelet/log"
-	"github.com/fatih/color"
 	md "github.com/nao1215/markdown"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -66,19 +64,5 @@ func createMarkdown(mdParam, planStr string) (*os.File, string, error) {
 	if mderr != nil {
 		log.Errorf("error generating %s markdown file, error: %s", mdParam, err)
 	}
-
-	// Checking to see if Markdown file was created.
-	if _, err := os.Stat(mdParam); err == nil {
-		log.Debugf("Markdown file %s was created.", mdParam)
-		fmt.Fprintf(color.Output, "%s%s\n", bold(green("✔")), "  Markdown Created...")
-	} else if errors.Is(err, os.ErrNotExist) {
-		//
-		log.Errorf("Markdown file %s was not created.", mdParam)
-		fmt.Fprintf(color.Output, "%s%s\n", bold(red("✕")), "  Failed to Create Markdown...")
-	} else {
-		// I'm only human. NFC how you got here. I hope to never have to find out.
-		log.Errorf("If you see this error message, please open a bug. Error Code: TPE003. Error: %s", err)
-	}
-
 	return planMd, mdParam, mderr
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -139,6 +139,20 @@ var rootCmd = &cobra.Command{
 			}
 		} else {
 			log.Errorf("No %s files found. Please run this in a directory with %s files present.", cases.Title(language.English).String(binary), cases.Title(language.English).String(binary))
+			os.Exit(1)
+		}
+
+		// Checking to see if Markdown file was created.
+		if _, err := os.Stat(mdParam); err == nil {
+			log.Debugf("Markdown file %s was created.", mdParam)
+			fmt.Fprintf(color.Output, "%s%s\n", bold(green("✔")), "  Markdown Created...")
+		} else if errors.Is(err, os.ErrNotExist) {
+			//
+			log.Errorf("Markdown file %s was not created.", mdParam)
+			fmt.Fprintf(color.Output, "%s%s\n", bold(red("✕")), "  Failed to Create Markdown...")
+		} else {
+			// I'm only human. NFC how you got here. I hope to never have to find out.
+			log.Errorf("If you see this error message, please open a bug. Error Code: TPE003. Error: %s", err)
 		}
 	},
 }


### PR DESCRIPTION
We currently have output like

```bash
gh tp
✔  Markdown Created...
✔  Plan Created...
```

But this isn't accurate. In order for the Markdown to be created, the plan had to be created first. The ordering is incorrect. While the _actual_ ordering is correct, the order in which we check for the presence of the files is out of order. This fixes that. Output now looks like

```bash
gh tp          
✔  Plan Created...
✔  Markdown Created...
```

This better represents the order of things as it _actually_ happens.
