### PR TITLE
build: ensures 'type: release' doesn't exist in 'whats changed'

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -20,7 +20,6 @@ changelog:
       labels:
         - "type: fix"
         - "type: bug"
-        - "type: refactor"
 
     - title: ":nail_polish: Style, UI, UX"
       labels:
@@ -42,4 +41,4 @@ changelog:
 
     - title: ":question: What's Changed"
       labels:
-        - "*"
+        - "type: refactor"


### PR DESCRIPTION
Fixes #8

Felt strange to see 'type: release' in `What's changed` on the release notes. This ensures it doesn't show up.
