### PR TITLE
feat: Use CONFIG_HOME for possible config location. Create it if it doesn't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ go.work.sum
 /gh-tp
 /gh-tp.exe
 
+# The world isn't ready for this. Or this isn't ready for the world
+/cmd/config_test.go
+
 #################
 # VSCode Things #
 #################

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ realbuild: tidy format audit
 
 	-gh tp --version
 
+
 .PHONY: reallyclean
 reallyclean: clean
 
@@ -89,13 +90,18 @@ ifneq (,$(wildcard ~/.tp.toml*))
 	rm ~/.tp.toml*
 endif
 
-ifneq (,$(wildcard ~/.config/tp.toml*))
-	rm ~/.config/tp.toml*
+ifneq (,$(wildcard ~/.config/*tp.toml*))
+	rm ~/.config/*tp.toml*
 endif
 
-ifneq (,$(wildcard /var/tmp/tp.toml*))
-	rm /var/tmp/tp.toml*
+ifneq (,$(wildcard /var/tmp/*tp.toml*))
+	rm /var/tmp/*tp.toml*
 endif
+
+ifneq (,$(wildcard ~/.config/gh-tp/.tp.toml*))
+	rm -rf ~/.config/gh-tp
+endif
+
 
 .PHONY: test
 test: realbuild

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,20 @@ format:
 tidy:
 	go mod tidy
 
-.PHONY: format
+
+.PHONY: realbuild
+realbuild: tidy format audit
+
+	goreleaser build --clean --single-target --snapshot
+	cp dist/gh-tp_linux_amd64_v1/gh-tp .
+
+	gh ext remove tp
+
+	gh ext install .
+
+	-gh tp --version
+
+.PHONY: reallyclean
 reallyclean: clean
 
 ifneq (,$(wildcard ./.tp.toml*))
@@ -83,3 +96,7 @@ endif
 ifneq (,$(wildcard /var/tmp/tp.toml*))
 	rm /var/tmp/tp.toml*
 endif
+
+.PHONY: test
+test: realbuild
+	go test ./...

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -41,7 +41,7 @@ type ConfigParams struct {
 func genConfig(conf ConfigParams) (data []byte, err error) {
 	data, err = toml.Marshal(conf)
 	if err != nil {
-		logger.Fatalf("Failed marshalling TOML: %s", err)
+		Logger.Fatalf("Failed marshalling TOML: %s", err)
 	}
 	return data, err
 }
@@ -52,14 +52,12 @@ func genConfig(conf ConfigParams) (data []byte, err error) {
 func createOrOverwrite(cfgFile string) (configExists, createFile bool) {
 	// configName = ".tp.toml"
 	configExists = doesExist(cfgFile + "/" + ConfigName)
-	logger.Debug(cfgFile + ConfigName)
+	Logger.Debugf("Using config: %s", cfgFile+ConfigName)
 	createFile, err := query(configExists)
 	if err != nil {
-		logger.Fatal(err)
+		Logger.Error(err)
 	}
 
-	// #69 logger.Debugf("inside mkFile() configExists is %t\n", configExists)
-	// #69 logger.Debugf("Inside mkFile() config is %s/%s\n", cfgFile, ConfigName)
 	return configExists, createFile
 }
 
@@ -84,7 +82,7 @@ func query(configExists bool) (createFile bool, err error) {
 
 	err = form.Run()
 	if err != nil {
-		logger.Fatal(err)
+		Logger.Error(err)
 	}
 
 	return createFile, err
@@ -102,20 +100,20 @@ func createConfig(cfgBinary, cfgFile, cfgMdFile, cfgPlanFile string) error {
 
 	config, err := genConfig(conf)
 	if err != nil {
-		logger.Fatal(err)
+		Logger.Error(err)
 	}
 
 	if createFile {
 		if !configExists {
 			// Figure out how to get in here
-			// logger.Debugf("Inside configExists and 'config' is: %s", string(config))
+			Logger.Debugf("Inside configExists and 'config' is: %s", string(config))
 			// Tracking this in #69
 			err = os.WriteFile(cfgFile+"/.tp.toml", config, 0o600) //nolint:mnd    // https://go.dev/ref/spec#Integer_literals
 			if err != nil {
-				logger.Fatalf("Error writing Config file: %s", err)
+				Logger.Fatalf("Error writing Config file: %s", err)
 			}
 		} else if configExists {
-			// #69 logger.Debugf("Inside !configExists and 'config' is: %s", string(config))
+			Logger.Debugf("Config is: \n%s\n", string(config))
 			localNow := time.Now().Local().Format("200601021504")
 
 			existingConfigFile := cfgFile + "/" + ConfigName
@@ -123,18 +121,18 @@ func createConfig(cfgBinary, cfgFile, cfgMdFile, cfgPlanFile string) error {
 			// Create Backup
 			err := backupFile(existingConfigFile, bkupConfigFile)
 			if err != nil {
-				logger.Fatal(err)
+				Logger.Fatal(err)
 			}
-			logger.Infof("Backup file %s created", bkupConfigFile)
+			Logger.Infof("Backup file %s created", bkupConfigFile)
 			// Create New File
 			err = os.WriteFile(cfgFile+"/.tp.toml", config, 0o600) //nolint:mnd    // https://go.dev/ref/spec#Integer_literals
 			if err != nil {
-				logger.Fatalf("Error writing Config file: %s", err)
+				Logger.Errorf("Error writing Config file: %s", err)
 			}
 		}
-		logger.Infof("Config file %s/.tp.toml created", cfgFile)
+		Logger.Infof("Config file %s/.tp.toml created", cfgFile)
 	} else if !createFile {
-		logger.Info(string(config))
+		Logger.Info(string(config))
 	}
 	return err
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/charmbracelet/huh"
@@ -63,22 +64,29 @@ func createOrOverwrite(cfgFile string) (configExists, createFile bool) {
 }
 
 func query(configExists bool) (createFile bool, err error) {
+	// Should we run in accessible mode?
+	accessible, _ = strconv.ParseBool(os.Getenv("ACCESSIBLE"))
+
 	if !configExists {
 		title = "Create new file?"
 	} else if configExists {
 		title = "Overwrite existing config file?"
 	}
-	err = huh.NewForm(
+	form := huh.NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title(title).
 				Affirmative("Yes").
 				Negative("No").
 				Value(&createFile),
-		)).WithTheme(huh.ThemeBase16()).Run()
+		)).WithTheme(huh.ThemeBase16()).
+		WithAccessible(accessible)
+
+	err = form.Run()
 	if err != nil {
 		logger.Fatal(err)
 	}
+
 	return createFile, err
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"os"
+	"time"
+
+	"github.com/charmbracelet/huh"
+	"github.com/pelletier/go-toml/v2"
+)
+
+var (
+	accessible   bool
+	binary       string
+	cfgBinary    string
+	cfgFile      string
+	cfgMdFile    string
+	cfgPlanFile  string
+	configDir    string
+	configExists bool
+	createFile   bool
+	homeDir      string
+	title        string
+)
+
+const TpDir = "gh-tp"
+
+const ConfigName = ".tp.toml"
+
+const DefaultXDGConfigDirName = ".config"
+
+type ConfigParams struct {
+	Binary   string `toml:"binary" comment:"binary: (type: string) The name of the binary, expect either 'tofu' or 'terraform'. Must exist on your $PATH." validate:"oneof=terraform tofu"`
+	PlanFile string `toml:"planFile" comment:"planFile: (type: string) The name of the plan file created by 'gh tp'." validate:"required"`
+	MdFile   string `toml:"mdFile" comment:"mdFile: (type: string) The name of the Markdown file created by 'gh tp'." validate:"required"`
+	Verbose  bool   `toml:"verbose" comment:"verbose: (type: bool) Enable Verbose Logging. Default is false." validate:"boolean"`
+}
+
+func genConfig(conf ConfigParams) (data []byte, err error) {
+	data, err = toml.Marshal(conf)
+	if err != nil {
+		logger.Fatalf("Failed marshalling TOML: %s", err)
+	}
+	return data, err
+}
+
+// Checks the existence of a config file
+// If one already exists, asks to overwrite
+// If one does not exist, asks to create
+func createOrOverwrite(cfgFile string) (configExists, createFile bool) {
+	// configName = ".tp.toml"
+	configExists = doesExist(cfgFile + "/" + ConfigName)
+	logger.Debug(cfgFile + ConfigName)
+	createFile, err := query(configExists)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	// #69 logger.Debugf("inside mkFile() configExists is %t\n", configExists)
+	// #69 logger.Debugf("Inside mkFile() config is %s/%s\n", cfgFile, ConfigName)
+	return configExists, createFile
+}
+
+func query(configExists bool) (createFile bool, err error) {
+	if !configExists {
+		title = "Create new file?"
+	} else if configExists {
+		title = "Overwrite existing config file?"
+	}
+	err = huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(title).
+				Affirmative("Yes").
+				Negative("No").
+				Value(&createFile),
+		)).WithTheme(huh.ThemeBase16()).Run()
+	if err != nil {
+		logger.Fatal(err)
+	}
+	return createFile, err
+}
+
+func createConfig(cfgBinary, cfgFile, cfgMdFile, cfgPlanFile string) error {
+	configExists, createFile = createOrOverwrite(cfgFile)
+
+	conf := ConfigParams{
+		Binary:   cfgBinary,
+		PlanFile: cfgPlanFile,
+		MdFile:   cfgMdFile,
+		Verbose:  false,
+	}
+
+	config, err := genConfig(conf)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	if createFile {
+		if !configExists {
+			// Figure out how to get in here
+			// logger.Debugf("Inside configExists and 'config' is: %s", string(config))
+			// Tracking this in #69
+			err = os.WriteFile(cfgFile+"/.tp.toml", config, 0o600) //nolint:mnd    // https://go.dev/ref/spec#Integer_literals
+			if err != nil {
+				logger.Fatalf("Error writing Config file: %s", err)
+			}
+		} else if configExists {
+			// #69 logger.Debugf("Inside !configExists and 'config' is: %s", string(config))
+			localNow := time.Now().Local().Format("200601021504")
+
+			existingConfigFile := cfgFile + "/" + ConfigName
+			bkupConfigFile := cfgFile + "/" + ConfigName + "-" + localNow
+			// Create Backup
+			err := backupFile(existingConfigFile, bkupConfigFile)
+			if err != nil {
+				logger.Fatal(err)
+			}
+			logger.Infof("Backup file %s created", bkupConfigFile)
+			// Create New File
+			err = os.WriteFile(cfgFile+"/.tp.toml", config, 0o600) //nolint:mnd    // https://go.dev/ref/spec#Integer_literals
+			if err != nil {
+				logger.Fatalf("Error writing Config file: %s", err)
+			}
+		}
+		logger.Infof("Config file %s/.tp.toml created", cfgFile)
+	} else if !createFile {
+		logger.Info(string(config))
+	}
+	return err
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // initCmd represents the init command
@@ -32,9 +33,16 @@ var initCmd = &cobra.Command{
 
 		View docs at https://github.com/esacteksab/gh-tp for more information.`),
 	Run: func(cmd *cobra.Command, args []string) {
+		// Check if Verbose is defined in config file
+		v := viper.IsSet("verbose")
+		if v {
+			Verbose = viper.GetBool("verbose")
+			createLogger(Verbose)
+		}
+
 		homeDir, configDir, cwd, err := getDirectories()
 		if err != nil {
-			logger.Fatalf("Error: %s", err)
+			Logger.Fatalf("Error: %s", err)
 		}
 
 		// Should we run in accessible mode?
@@ -125,13 +133,13 @@ var initCmd = &cobra.Command{
 
 		err = form.Run()
 		if err != nil {
-			logger.Fatal(err)
+			Logger.Fatal(err)
 		}
 
 		// createConfig() Goes Here
 		err = createConfig(cfgBinary, cfgFile, cfgMdFile, cfgPlanFile)
 		if err != nil {
-			logger.Fatal(err)
+			Logger.Fatal(err)
 		}
 	},
 }

--- a/cmd/markdown.go
+++ b/cmd/markdown.go
@@ -32,7 +32,7 @@ const (
 func createMarkdown(mdParam, planStr string) (*os.File, string, error) {
 	planMd, err = os.Create(mdParam)
 	if err != nil {
-		logger.Errorf("failed to create Markdown: %s\n", err)
+		Logger.Errorf("failed to create Markdown: %s\n", err)
 	}
 
 	// Close the file when we're done with it
@@ -42,7 +42,7 @@ func createMarkdown(mdParam, planStr string) (*os.File, string, error) {
 	planBody = md.NewMarkdown(os.Stdout).
 		CodeBlocks(md.SyntaxHighlight(SyntaxHighlightTerraform), planStr)
 	if err != nil {
-		logger.Errorf("error generating plan Markdown: %s\n", err)
+		Logger.Errorf("error generating plan Markdown: %s\n", err)
 	}
 
 	// NewMarkdown returns io.Writer
@@ -60,22 +60,23 @@ func createMarkdown(mdParam, planStr string) (*os.File, string, error) {
 	// This is what creates the final document (`mdoutfile`) plmd here could possibly be os.Stdout one day
 	mderr := md.NewMarkdown(planMd).Details(planDetails, sbPlan).Build()
 	if mderr != nil {
-		logger.Errorf("error generating %s markdown file, error: %s", mdParam, err)
+		Logger.Errorf("error generating %s markdown file, error: %s", mdParam, err)
 	}
 
 	// planMd doesn't have a new line at eof, we need to give it one because Markdown
-	// Open the file
 	file, err := os.OpenFile("./"+mdParam, os.O_APPEND|os.O_WRONLY, 0o644) //nolint:mnd
 	if err != nil {
-		logger.Error(err)
+		Logger.Errorf("Unable to create Markdown: %s\n", err)
 	}
 
 	// Add new line
 	_, err = file.WriteString("\n\n")
 	if err != nil {
-		logger.Error(err)
+		Logger.Error(err)
 	}
 
+	// Close file
 	file.Close()
+
 	return planMd, mdParam, mderr
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,9 @@ import (
 
 var (
 	binaries           []string
+	configDir          string
+	cfgFile            string
+	homeDir            string
 	out                io.Reader
 	MaxWidth           int
 	mdParam            string
@@ -41,6 +44,13 @@ var (
 	red                = color.New(color.FgRed).SprintFunc()
 )
 
+const TpDir = "gh-tp"
+
+const ConfigName = ".tp.toml"
+
+// A struct representing the files created by tp
+// An Plan (Purpose) file named (Name)
+// A  Markdown (Purpose) file named (Name)
 type tpFile struct {
 	Name    string
 	Purpose string
@@ -236,7 +246,7 @@ func init() {
 			"",
 			`use this configuration file (default lookup:
 			1. a .tp.toml file in your project's root
-			2. $XDG_CONFIG_HOME/.tp.toml
+			2. $XDG_CONFIG_HOME/gh-tp/.tp.toml
 			3. $HOME/.tp.toml)`)
 
 	// Cobra also supports local flags, which will only run
@@ -248,18 +258,24 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+	configFile := ConfigFile{}
 	if cfgFile != "" {
 		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
+		viper.SetConfigFile(configFile.Path)
+		// Set the Path in ConfigFile struct
+		configFile.Path = cfgFile
 	} else {
 		// Find home directory and home config directory.
 		homeDir, configDir, _, _ = getDirectories()
 
 		// Search config in home directory with name ".tp.toml"
+		// Current Working Directory - Presumed project's root
 		viper.SetConfigName(".tp.toml")
 		viper.SetConfigType("toml")
 		viper.AddConfigPath(".")
-		viper.AddConfigPath(configDir)
+		// $XDG_CONFIG_HOME/gh-tp
+		viper.AddConfigPath(configDir + "/" + TpDir)
+		// os.UserHomeDir
 		viper.AddConfigPath(homeDir)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,11 +8,9 @@ import (
 	"os"
 	"runtime"
 	"runtime/debug"
-	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"github.com/cli/safeexec"
 	"github.com/fatih/color"
@@ -25,7 +23,6 @@ import (
 var (
 	binaries           []string
 	out                io.Reader
-	logger             *log.Logger
 	MaxWidth           int
 	mdParam            string
 	spinnerDuration    time.Duration
@@ -38,6 +35,7 @@ var (
 	BuiltBy            string
 	exts               []string
 	workingDir         string
+	Logger             *log.Logger
 	bold               = color.New(color.Bold).SprintFunc()
 	green              = color.New(color.FgGreen).SprintFunc()
 	red                = color.New(color.FgRed).SprintFunc()
@@ -88,28 +86,22 @@ var rootCmd = &cobra.Command{
 		v := viper.IsSet("verbose")
 		if v {
 			Verbose = viper.GetBool("verbose")
-		}
-		if err != nil {
-			logger.Fatal("Unable to enable verbose output:", err)
-		}
-		if Verbose {
-			logger.SetLevel(log.DebugLevel)
-			logger.Debug("I'm a Debug statement in initConfig().")
+			createLogger(Verbose)
 		}
 
 		keys := viper.AllKeys()
-		logger.Debugf("Defined keys: %s in %s", keys, viper.ConfigFileUsed())
+		Logger.Debugf("Defined keys: %s in %s", keys, viper.ConfigFileUsed())
 
 		if !doesExist(viper.ConfigFileUsed()) {
-			logger.Debug(viper.ConfigFileUsed())
-			logger.Error("Config file not found. Please run 'gh tp init' or run 'gh tp help' or refer to the documentation on how to create a config file. https://github.com/esacteksab/gh-tp")
+			Logger.Debug(viper.ConfigFileUsed())
+			Logger.Error("Config file not found. Please run 'gh tp init' or run 'gh tp help' or refer to the documentation on how to create a config file. https://github.com/esacteksab/gh-tp")
 			os.Exit(1)
 			// May want to put cmd.Help() or something about expectations with config parameters.
 		} else {
 			// Check to see if required 'planFile' parameter is set
 			o := viper.IsSet("planFile")
 			if !o {
-				logger.Errorf(
+				Logger.Errorf(
 					"Missing Parameter: 'planFile' (type: string) is not defined in %s. This is the name of the plan's output file that will be created by `gh tp`.\n", viper.ConfigFileUsed())
 				os.Exit(1)
 			}
@@ -117,11 +109,11 @@ var rootCmd = &cobra.Command{
 			// Check to see if required 'mdFile' parameter is set
 			m := viper.IsSet("mdFile")
 			if !m {
-				logger.Errorf(
+				Logger.Errorf(
 					"Missing Parameter: 'mdFile' (type: string) is not defined in %s. This is the name of the Markdown file that will be created by `gh tp`.\n", viper.ConfigFileUsed())
 				os.Exit(1)
 			}
-			logger.Debugf("Using config file: %s", viper.ConfigFileUsed())
+			Logger.Debugf("Using config file: %s", viper.ConfigFileUsed())
 		}
 
 		b := viper.IsSet("binary")
@@ -133,7 +125,7 @@ var rootCmd = &cobra.Command{
 			for _, v := range binaries {
 				bin, err := safeexec.LookPath(v)
 				if err != nil {
-					logger.Debugf("%s", err)
+					Logger.Debugf("%s", err)
 				}
 				// It's possible for both `tofu` and `terraform` to exist on $PATH and we need to handle that.
 				if len(bin) > 0 {
@@ -141,7 +133,7 @@ var rootCmd = &cobra.Command{
 				}
 			}
 			if len(exists) == len(binaries) {
-				logger.Errorf("Found both `tofu` and `terraform` in your $PATH. We're not sure which one to use. Please set the 'binary' parameter in your %s config file to the binary you want to use.", viper.ConfigFileUsed())
+				Logger.Errorf("Found both `tofu` and `terraform` in your $PATH. We're not sure which one to use. Please set the 'binary' parameter in your %s config file to the binary you want to use.", viper.ConfigFileUsed())
 				os.Exit(1)
 			}
 		}
@@ -154,35 +146,35 @@ var rootCmd = &cobra.Command{
 			if len(args) == 0 {
 				planStr, err = createPlan()
 				if err != nil {
-					logger.Errorf("Unable to create plan: %s", err)
+					Logger.Errorf("Unable to create plan: %s", err)
 				}
 				// Create the Markdown from the Plan.
 				planMd, mdParam, err = createMarkdown(mdParam, planStr)
 				if err != nil {
-					logger.Errorf("Something is not right, %s", err)
+					Logger.Errorf("Something is not right, %s", err)
 				}
 
 			} else if args[0] == "-" {
 				out = cmd.InOrStdin()
 				content, err := io.ReadAll(out)
 				if err != nil {
-					logger.Errorf("unable to read stdIn: %s", err)
+					Logger.Errorf("unable to read stdIn: %s", err)
 				}
 
 				mdParam = viper.GetString("mdFile")
 
 				planStr := string(content)
 
-				logger.Debugf("Plan output is: %s\n", planStr)
+				Logger.Debugf("Plan output is: %s\n", planStr)
 				// Create the plan from Stdin.
 				planMd, mdParam, err = createMarkdown(mdParam, planStr)
 				if err != nil {
-					logger.Errorf("Something is not right, %s", err)
+					Logger.Errorf("Something is not right, %s", err)
 				}
 				// the arg received looks like a file, we try to open it
 			}
 		} else {
-			logger.Errorf("No %s files found. Please run this in a directory with %s files present.",
+			Logger.Errorf("No %s files found. Please run this in a directory with %s files present.",
 				cases.Title(language.English).String(binary), cases.Title(language.English).String(binary))
 			os.Exit(1)
 		}
@@ -194,7 +186,7 @@ var rootCmd = &cobra.Command{
 
 		tpFilesErr := existsOrCreated(tpFiles)
 		if tpFilesErr != nil {
-			logger.Error(err)
+			Logger.Error(err)
 		}
 	},
 }
@@ -202,6 +194,7 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	createLogger(Verbose)
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
@@ -209,56 +202,31 @@ func Execute() {
 }
 
 func init() {
-	logger = log.NewWithOptions(os.Stderr, log.Options{
-		ReportCaller:    false,
-		ReportTimestamp: false,
-		TimeFormat:      time.Kitchen,
-	})
-	MaxWidth = 4
-	styles := log.DefaultStyles()
-	styles.Levels[log.DebugLevel] = lipgloss.NewStyle().
-		SetString(strings.ToUpper(log.DebugLevel.String())).
-		Bold(true).MaxWidth(MaxWidth).Foreground(lipgloss.Color("12"))
-	logger.SetStyles(styles)
-	logger.Debug("Testing new Debug")
-	logger.Debugf("I'm inside initConfig() and Verbose is %t:\n", Verbose)
-
 	cobra.OnInitialize(initConfig)
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
-	rootCmd.Flags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
+	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.Flags().StringP("binary", "b", "", "The name of the binary to use. Expect either `tofu` or `terraform`. Must exist on your $PATH.")
 	rootCmd.Flags().StringP("outFile", "o", "", "The name of the plan output file created by tp.")
 	rootCmd.Flags().StringP("mdFile", "m", "", "The name of the Markdown file created by tp.")
 
-	err := viper.BindPFlag("verbose", rootCmd.Flags().Lookup("verbose"))
+	err := viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
 	if err != nil {
-		logger.Error("Unable to bind to verbose flag: ", err)
+		Logger.Error("Unable to bind to verbose flag: ", err)
 	}
 	err = viper.BindPFlag("binary", rootCmd.Flags().Lookup("binary"))
 	if err != nil {
-		logger.Error("Unable to bind to binary flag: ", err)
+		Logger.Error("Unable to bind to binary flag: ", err)
 	}
 	err = viper.BindPFlag("planFile", rootCmd.Flags().Lookup("outFile"))
 	if err != nil {
-		logger.Error("Unable to bind to planFile flag: ", err)
+		Logger.Error("Unable to bind to planFile flag: ", err)
 	}
 	err = viper.BindPFlag("mdFile", rootCmd.Flags().Lookup("mdFile"))
 	if err != nil {
-		logger.Error("Unable to bind to mdFile flag: ", err)
-	}
-
-	Verbose, err := rootCmd.Flags().GetBool("verbose")
-	logger.Debug("I'm inside init, Verbose is %t\n", Verbose)
-	if err != nil {
-		logger.Errorf("Unable to get verbose flag: %s", err)
-	}
-
-	if Verbose {
-		logger.SetLevel(log.DebugLevel)
-		logger.Errorf("I'm inside !Verbose init() and my value is %t\n", Verbose)
+		Logger.Error("Unable to bind to mdFile flag: ", err)
 	}
 
 	rootCmd.Flags().
@@ -300,11 +268,11 @@ func initConfig() {
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.UnsupportedConfigError); ok {
-			logger.Errorf("Unsupported Format. Config file should be named .tp.toml %s.", err)
+			Logger.Errorf("Unsupported Format. Config file should be named .tp.toml %s.", err)
 			os.Exit(1)
 			// This handles the situation where a duplicate key exists.
 		} else if _, ok := err.(viper.ConfigParseError); ok {
-			logger.Errorf("There is an issue %s.", err)
+			Logger.Errorf("There is an issue %s.", err)
 			os.Exit(1)
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,7 +100,7 @@ var rootCmd = &cobra.Command{
 		keys := viper.AllKeys()
 		logger.Debugf("Defined keys: %s in %s", keys, viper.ConfigFileUsed())
 
-		if doesNotExist(viper.ConfigFileUsed()) {
+		if !doesExist(viper.ConfigFileUsed()) {
 			logger.Debug(viper.ConfigFileUsed())
 			logger.Error("Config file not found. Please run 'gh tp init' or run 'gh tp help' or refer to the documentation on how to create a config file. https://github.com/esacteksab/gh-tp")
 			os.Exit(1)

--- a/cmd/tools.go
+++ b/cmd/tools.go
@@ -103,6 +103,9 @@ func backupFile(source, dest string) error {
 	return err
 }
 
+// initLogger is how we initially create Logger. The values passed are based on 'Verbose' being true
+// Colors are defined here https://github.com/charmbracelet/x/blob/aedd0cd23ed703ff7cbccc5c4f9ab51a4768a9e6/ansi/color.go#L15-L32
+// 14 is Bright Cyan, 9 is Red -- no more purple
 func initLogger(ReportCaller, ReportTimestamp bool, TimeFormat string) (Logger *log.Logger) {
 	Logger = log.NewWithOptions(os.Stderr, log.Options{
 		ReportCaller:    ReportCaller,

--- a/cmd/tools.go
+++ b/cmd/tools.go
@@ -38,11 +38,13 @@ func existsOrCreated(files []tpFile) error {
 		exists := doesExist(v.Name)
 		if exists {
 			Logger.Debugf("%s file %s was created.", v.Purpose, v.Name)
-			fmt.Fprintf(color.Output, "%s  %s%s\n", bold(green("✔")), v.Purpose, " Created...")
+			fmt.Fprintf(color.Output, "%s  %s%s\n",
+				bold(green("✔")), v.Purpose, " Created...")
 		} else if !exists {
 			//
 			Logger.Errorf("Markdown file %s was not created.", v.Name)
-			fmt.Fprintf(color.Output, "%s  %s%s\n", bold(red("✕")), v.Purpose, " Failed to Create ...")
+			fmt.Fprintf(color.Output, "%s  %s%s\n",
+				bold(red("✕")), v.Purpose, " Failed to Create ...")
 		} else {
 			// I'm only human. NFC how you got here. I hope to never have to find out.
 			Logger.Errorf("If you see this error message, please open a bug. Error Code: TPE003. Error: %s", err)
@@ -60,6 +62,8 @@ func doesExist(path string) bool {
 	return true
 }
 
+// getDirectories returns User's home directory, $XDG_CONFIG_HOME
+// and Current Working Directory
 func getDirectories() (homeDir, configDir, cwd string, err error) {
 	homeDir, err = os.UserHomeDir()
 	if err != nil {

--- a/cmd/tools.go
+++ b/cmd/tools.go
@@ -3,16 +3,13 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 
-	"github.com/adrg/xdg"
-	"github.com/charmbracelet/huh"
 	"github.com/fatih/color"
-	"github.com/pelletier/go-toml/v2"
 )
 
 func checkFilesByExtension(dir string, exts []string) bool {
@@ -31,12 +28,15 @@ func checkFilesByExtension(dir string, exts []string) bool {
 	return exists
 }
 
+// existsOrCreate checks to see if a plan file and markdown exist or were created
+// Prints to terminal stating so
 func existsOrCreated(files []tpFile) error {
 	for _, v := range files {
-		if _, err := os.Stat(v.Name); err == nil {
+		exists := doesExist(v.Name)
+		if exists {
 			logger.Debugf("%s file %s was created.", v.Purpose, v.Name)
 			fmt.Fprintf(color.Output, "%s  %s%s\n", bold(green("✔")), v.Purpose, " Created...")
-		} else if errors.Is(err, os.ErrNotExist) {
+		} else if !exists {
 			//
 			logger.Errorf("Markdown file %s was not created.", v.Name)
 			fmt.Fprintf(color.Output, "%s  %s%s\n", bold(red("✕")), v.Purpose, " Failed to Create ...")
@@ -48,77 +48,31 @@ func existsOrCreated(files []tpFile) error {
 	return err
 }
 
-// Feels like a bit of a duplicate to the above function, this takes a path string an returns a bool
-// on whether or not the path exists -- TODO #66 probably worth deduping this eventually
-func doesNotExist(path string) bool {
+// doesExist takes a path string and returns a bool
+// on whether or not the path exists
+func doesExist(path string) bool {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return true
+		return false
 	}
-	return false
+	return true
 }
 
 func getDirectories() (homeDir, configDir, cwd string, err error) {
-	homeDir = xdg.Home
+	homeDir, err = os.UserHomeDir()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	configDir = xdg.ConfigHome
+	configDir, err = os.UserConfigDir()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	cwd, cwderr := os.Getwd()
 	if cwderr != nil {
 		logger.Errorf("Error: %s", err)
 	}
 	return homeDir, configDir, cwd, err
-}
-
-func genConfig(conf ConfigParams) (data []byte, err error) {
-	data, err = toml.Marshal(conf)
-	if err != nil {
-		logger.Fatalf("Failed marshalling TOML: %s", err)
-	}
-	return data, err
-}
-
-// takes cfgFile, appends ".tp.toml" to it
-// checks to see if file exists
-// based on existence, asks to create (doesn't exist)
-// or overwrite (exists)
-func mkFile(cfgFile string) (exists, createFile bool) {
-	configName = ".tp.toml"
-	noConfig := doesNotExist(cfgFile + "/" + configName)
-	logger.Debug(cfgFile + configName)
-	if noConfig {
-		logger.Debugf("%s/%s doesn't exist\n", cfgFile, configName)
-		err := huh.NewForm(
-			huh.NewGroup(
-				huh.NewConfirm().
-					Title("Create new file?").
-					Affirmative("Yes").
-					Negative("No").
-					Value(&createFile),
-			)).WithTheme(huh.ThemeBase16()).Run()
-		if err != nil {
-			logger.Fatal(err)
-		}
-		logger.Debugf("Inside mkFile() and config is %s/%s\n", cfgFile, configName)
-		return noConfig, createFile
-	} else if !noConfig {
-		err := huh.NewForm(
-			huh.NewGroup(
-				huh.NewConfirm().
-					Title("Overwrite existing config file?").
-					Affirmative("Yes").
-					Negative("No").
-					Value(&createFile),
-			)).WithTheme(huh.ThemeBase16()).Run()
-		if err != nil {
-			logger.Fatal(err)
-		}
-		logger.Debugf("Inside mkFile if exists, config is %s/%s\n", cfgFile, configName)
-		return noConfig, createFile
-	}
-
-	logger.Debugf("inside mkFile() noConfig is %t\n", noConfig)
-	logger.Debugf("Inside mkFile() config is %s/%s\n", cfgFile, configName)
-	return noConfig, createFile
 }
 
 // backupFile copies the file at source to dest

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.24
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
-	github.com/adrg/xdg v0.5.3
 	github.com/briandowns/spinner v1.23.2
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/huh v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
 github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
-github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=


### PR DESCRIPTION
- **build: shuffling targets, belts and suspenders**
- **refactor: initial effort to refactor things to support XDG_CONFIG_HOME/gh-tp**
- **feat: enables accessibility mode on confirmation dialog**
- **fix: fixes #69. Can now get Debug statements from huh calls**
- **chore: Adding a comment linking to the color source and values**
- **chore: make really really clean target**
- **feat: uses config home as a possible location**
