### PR TITLE
docs: This captures the gh-tp directory that may get created in XDG_CONFIG_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ gh ext install esacteksab/gh-tp
 
 ### `.tp.toml` config file
 
-I wanted to make as few assumptions about your environment as possible, so `tp` defines one default value `verbose = false` today. `tp` uses a config file named `.tp.toml`. This config file is written in [TOML](https://toml.io/). TOML is case-sensitive and keys are [mixedCase or camelCase](https://en.wikipedia.org/wiki/Camel_case) where applicable. It has 2 required parameters with two optional parameters. The lookup order for locating the config file is, your project's root (.e.g '.tp.toml'), `$XDG_CONFIG_HOME/.tp.toml`, on \*nix this is `~/.config`, on MacOS this is `~/Library/Application Support`, on Windows this is `LocalAppData` falling back to `%LOCALAPPDATA%` and finally, we look in `$HOME/.tp.toml`.
+I wanted to make as few assumptions about your environment as possible, so `tp` defines one default value `verbose = false` today. `tp` uses a config file named `.tp.toml`. This config file is written in [TOML](https://toml.io/). TOML is case-sensitive and keys are [mixedCase or camelCase](https://en.wikipedia.org/wiki/Camel_case) where applicable. It has 2 required parameters with two optional parameters. The lookup order for locating the config file is, your project's root (.e.g `.tp.toml`), `$XDG_CONFIG_HOME/gh-tp/.tp.toml`, on \*nix this is `~/.config/gh-tp`, on MacOS this is `~/Library/Application Support/gh-tp`, on Windows this is `LocalAppData/gh-tp` falling back to `%LOCALAPPDATA%` and finally, we look in `$HOME/.tp.toml`.
 
 A annotated copy exists in the [example](./example) directory. **_The config file, the parameters and possibly the presence of default values is actively being worked on. This behavior may change in a future release._**
 

--- a/example/EXAMPLE-Config-tp.toml
+++ b/example/EXAMPLE-Config-tp.toml
@@ -3,12 +3,11 @@
 # Currently expects TOML -- https://toml.io
 # TOML is case-sensitive | Keys are mixedCase
 
-# Type: String. Name of the binary (e.g tofu or terraform. Must exist in your $PATH)
-# This parameter is only required to be set if both `tofu` and `terraform` exist on your $PATH.
-#binary = ""
-
-# Type: String. The name of the plan output file created with `gh tp`
-planFile = ""
-
-# Type: String. The name of the Markdown file that will be created with `gh tp``
-mdFile = ""
+# binary: (type: string) The name of the binary, expect either 'tofu' or 'terraform'. Must exist on your $PATH. Only required if both binaries exist on your $PATH.
+# binary = ''
+# planFile: (type: string) The name of the plan file created by 'gh tp'.
+planFile = ''
+# mdFile: (type: string) The name of the Markdown file created by 'gh tp'.
+mdFile = ''
+# verbose: (type: bool) Enable Verbose Logging. Default is false.
+verbose = false


### PR DESCRIPTION
Forgot to update the docs for 0.3.0 which may create a directory called `gh-tp` in `$XDG_CONFIG_HOME` so the config file may now live at `~/.config/gh-tp/.tp.toml` rather than `~/.config/.tp.toml`.
