### PR TITLE
fix: --config now uses the config file that was passed to it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ ifneq (,$(wildcard ./*.tf))
 	rm *.tf
 endif
 
+ifneq (,$(wildcard ./*.tfstate))
+	rm *.tfstate
+endif
+
 ifneq (,$(wildcard ./*.tofu))
 	rm *.tofu
 endif
@@ -104,5 +108,9 @@ endif
 
 
 .PHONY: test
-test: realbuild
+test:
+	go test ./...
+
+.PHONY: reallytest
+reallytest: realbuild
 	go test ./...

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -261,9 +261,9 @@ func initConfig() {
 	configFile := ConfigFile{}
 	if cfgFile != "" {
 		// Use config file from the flag.
-		viper.SetConfigFile(configFile.Path)
+		viper.SetConfigFile(cfgFile)
 		// Set the Path in ConfigFile struct
-		configFile.Path = cfgFile
+		cfgFile = configFile.Path
 	} else {
 		// Find home directory and home config directory.
 		homeDir, configDir, _, _ = getDirectories()


### PR DESCRIPTION
- **fix: 0.3.0 broke the use of --config so while a config was passed, it wasn't being used**
- **chore: shuffling make targets based on need**
