### PR TITLE
chore: update shared workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
           - "patch"
     schedule:
       interval: "weekly"
-      day: "saturday"
-      time: "03:00"
+      day: "friday"
+      time: "19:00"
       timezone: "America/Chicago"
 
   - package-ecosystem: "gomod"
@@ -22,7 +22,7 @@ updates:
           - "patch"
     schedule:
       interval: "daily"
-      time: "03:00"
+      time: "19:00"
       timezone: "America/Chicago"
 
   - package-ecosystem: "npm"
@@ -34,20 +34,20 @@ updates:
           - "patch"
     schedule:
       interval: "weekly"
-      day: "saturday"
-      time: "03:00"
+      day: "friday"
+      time: "19:00"
       timezone: "America/Chicago"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "03:00"
+      interval: "weekly"
+      time: "19:00"
       timezone: "America/Chicago"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "03:00"
+      interval: "weekly"
+      time: "19:00"
       timezone: "America/Chicago"

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -24,4 +24,4 @@ permissions:
 
 jobs:
   audit-reusable:
-    uses: esacteksab/.github/.github/workflows/go-ci.yml@7da1f735f5f18ecf049b40ab75503b1191756456 #0.5.3
+    uses: esacteksab/.github/.github/workflows/go-ci.yml@4d7de537e7e37efb571e2f24c01aa0fdbd3cef7b #0.6.0

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -16,4 +16,4 @@ permissions:
 
 jobs:
   goreleaser-reusable:
-    uses: esacteksab/.github/.github/workflows/go-release.yml@7da1f735f5f18ecf049b40ab75503b1191756456 #0.5.3
+    uses: esacteksab/.github/.github/workflows/go-release.yml@4d7de537e7e37efb571e2f24c01aa0fdbd3cef7b #0.6.0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,4 +28,4 @@ permissions:
 
 jobs:
   golangci-reusable:
-    uses: esacteksab/.github/.github/workflows/golangci-lint.yml@7da1f735f5f18ecf049b40ab75503b1191756456 #0.5.3
+    uses: esacteksab/.github/.github/workflows/golangci-lint.yml@4d7de537e7e37efb571e2f24c01aa0fdbd3cef7b #0.6.0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   label-pr:
-    uses: esacteksab/.github/.github/workflows/labeler.yml@7da1f735f5f18ecf049b40ab75503b1191756456 #0.5.3
+    uses: esacteksab/.github/.github/workflows/labeler.yml@4d7de537e7e37efb571e2f24c01aa0fdbd3cef7b #0.6.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   precommit-reusable:
-    uses: esacteksab/.github/.github/workflows/pre-commit.yml@7da1f735f5f18ecf049b40ab75503b1191756456 #0.5.3
+    uses: esacteksab/.github/.github/workflows/pre-commit.yml@4d7de537e7e37efb571e2f24c01aa0fdbd3cef7b #0.6.0

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -16,4 +16,4 @@ concurrency:
 
 jobs:
   typos-reusable:
-    uses: esacteksab/.github/.github/workflows/spelling.yml@7da1f735f5f18ecf049b40ab75503b1191756456 #0.5.3
+    uses: esacteksab/.github/.github/workflows/spelling.yml@4d7de537e7e37efb571e2f24c01aa0fdbd3cef7b #0.6.0

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
   goreleaser-check-reusable:
-    uses: esacteksab/.github/.github/workflows/tools.yml@7da1f735f5f18ecf049b40ab75503b1191756456 #0.5.3
+    uses: esacteksab/.github/.github/workflows/tools.yml@4d7de537e7e37efb571e2f24c01aa0fdbd3cef7b #0.6.0


### PR DESCRIPTION
In addition t updating the workflows to their latest version, we're also telling Dependabot to update during waking hours rather than waking us at 0300.
