### PR TITLE
chore: pin go version in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,12 +69,10 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/"
-    allow:
-      - dependency-name: "esacteksab/go"
     ignore:
       - dependency-name: "esacteksab/go"
         update-types:
-          - "version-update:semver-major"
+          - "version-update:semver-minor"
     schedule:
       interval: "weekly"
       day: "friday"


### PR DESCRIPTION
This is an attempt to pin Go image to 1.25 rather than trying to upgrade to 1.26.