### PR TITLE
chore: allow esacteksab/go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,84 +1,86 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
+  - package-ecosystem: pip
+    directory: /
     groups:
       minor-and-patch-py:
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
     schedule:
-      interval: "weekly"
-      day: "friday"
-      time: "17:00"
-      timezone: "America/Chicago"
+      interval: weekly
+      day: friday
+      time: 17:00
+      timezone: America/Chicago
     labels:
-      - "dependencies"
-      - "dev"
-      - "python"
+      - dependencies
+      - dev
+      - python
 
-  - package-ecosystem: "gomod"
-    directory: "/"
+  - package-ecosystem: gomod
+    directory: /
     groups:
       minor-and-patch-go:
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
     schedule:
-      interval: "daily"
-      time: "17:00"
-      timezone: "America/Chicago"
+      interval: daily
+      time: 17:00
+      timezone: America/Chicago
     labels:
-      - "dependencies"
-      - "go"
+      - dependencies
+      - go
 
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: npm
+    directory: /
     groups:
       minor-and-patch-npm:
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
     schedule:
-      interval: "weekly"
-      day: "friday"
-      time: "17:00"
-      timezone: "America/Chicago"
+      interval: weekly
+      day: friday
+      time: 17:00
+      timezone: America/Chicago
     labels:
-      - "dependencies"
-      - "dev"
-      - "javascript"
+      - dependencies
+      - dev
+      - javascript
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     groups:
       github-actions:
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
     schedule:
-      interval: "weekly"
-      day: "friday"
-      time: "17:00"
-      timezone: "America/Chicago"
+      interval: weekly
+      day: friday
+      time: 17:00
+      timezone: America/Chicago
     labels:
-      - "dependencies"
-      - "dev"
-      - "github_actions"
+      - dependencies
+      - dev
+      - github_actions
 
-  - package-ecosystem: "docker"
-    directory: "/"
+  - package-ecosystem: docker
+    directory: /
+    allow:
+      - dependency-name: esacteksab/go
     ignore:
-      - dependency-name: "esacteksab/go"
+      - dependency-name: esacteksab/go
         update-types:
-          - "version-update:semver-minor"
+          - version-update:semver-minor
     schedule:
-      interval: "weekly"
-      day: "friday"
-      time: "17:00"
-      timezone: "America/Chicago"
+      interval: weekly
+      day: friday
+      time: 17:00
+      timezone: America/Chicago
     labels:
-      - "dependencies"
-      - "dev"
-      - "docker"
+      - dependencies
+      - dev
+      - docker


### PR DESCRIPTION
This allows `esacteksab/go` but ignores `version-update:semver-minor`. The combo should allow 1.25 updates, but not update to 1.26.
